### PR TITLE
New version 0.1.0a

### DIFF
--- a/src/html/attachmentEditHead.php
+++ b/src/html/attachmentEditHead.php
@@ -1,0 +1,2 @@
+<link rel="stylesheet" type="text/css" href="<?php echo site_url('wp-includes/js/imgareaselect/imgareaselect.css'); ?>" />
+<script type="text/javascript" src="<?php echo admin_url('load-scripts.php?load=jquery-color,imgareaselect,image-edit,wp-ajax-response,set-post-thumbnail'); ?>"></script>

--- a/src/html/attachmentEditIframe.php
+++ b/src/html/attachmentEditIframe.php
@@ -1,0 +1,15 @@
+	<form action="<?php echo $url; ?>" method="post" style="padding:0 10px 10px" class="media-item">
+		<div class="submit"><input type="submit" class="button-primary" value="<?php _e('Update Media'); ?>" /></div>
+		<input type="hidden" name="action" value="editattachment" />
+		<input type="hidden" name="attachment_id" value="<?php echo $id; ?>" />
+		<?php
+		wp_nonce_field('media-form');
+		wp_original_referer_field(true, 'current');
+
+		echo get_media_item($id, array(
+			'toggle'        => false,
+			'show_title'    => false
+		));
+		?>
+		<div class="submit"><input type="submit" class="button-primary" value="<?php _e('Update Media'); ?>" /></div>
+	</form>

--- a/src/html/metabox.php
+++ b/src/html/metabox.php
@@ -6,7 +6,7 @@
 	</p>
 	<?php if ($attachments->have_posts()): ?>
 	<div id="ij-post-attachments" class="ij-post-attachment-list">
-		<ul>
+		<ul class="alignleft">
 			<?php while ($attachments->have_posts()): $atchment = $attachments->next_post(); ?>
 			<li class="ij-post-attachment"
 			    data-mimetype="<?php echo $atchment->post_mime_type; ?>"

--- a/src/html/metabox.php
+++ b/src/html/metabox.php
@@ -1,0 +1,44 @@
+	<p>
+		<a href="<?php echo admin_url('media-upload.php?post_id=' . $post->ID); ?>&TB_iframe=1&width=640&height=693"
+			onclick="return false" class="button-primary thickbox">
+			<?php _e('Add Media'); ?>
+		</a>
+	</p>
+	<?php if ($attachments->have_posts()): ?>
+	<div id="ij-post-attachments" class="ij-post-attachment-list">
+		<ul>
+			<?php while ($attachments->have_posts()): $atchment = $attachments->next_post(); ?>
+			<li class="ij-post-attachment"
+			    data-mimetype="<?php echo $atchment->post_mime_type; ?>"
+			    data-alt="<?php echo get_post_meta(611, '_wp_attachment_image_alt', true); ?>"
+			    data-attachmentid="<?php echo $atchment->ID; ?>"
+			    data-url="<?php echo wp_get_attachment_url($atchment->ID); ?>"
+			    data-title="<?php echo $atchment->post_title; ?>">
+
+				<!--Item title-->
+				<div class="ij-post-attachment-title" title="<?php echo $atchment->post_title; ?>">
+					<a href="<?php echo wp_get_attachment_url($atchment->ID); ?>" class="ij-post-attachment-edit">
+						<strong><?php echo (strlen($atchment->post_title) > 22) ? (substr($atchment->post_title, 0, 22) . '...') : $atchment->post_title; ?></strong>
+					</a>
+				</div>
+
+				<!--Item body-->
+				<div style="padding:1px 5px 5px">
+					<div class="ij-post-attachment-type">
+						<?php echo strtoupper(str_replace('image/', '', get_post_mime_type($atchment->ID))); ?>
+					</div>
+					<?php echo wp_get_attachment_image($atchment->ID, array(80, 60), true); ?>
+					<div style="float:left">
+						<a href="#" class="ij-post-attachment-insert"><?php _e('Insert'); ?></a><br />
+						<a href="<?php echo wp_get_attachment_url($atchment->ID); ?>" class="ij-post-attachment-edit"><?php _e('Edit'); ?></a><br />
+						<a href="<?php echo wp_nonce_url(admin_url('post.php') . '?action=delete&post=' . $atchment->ID, 'delete-attachment_' . $atchment->ID); ?>" class="ij-post-attachment-delete"><?php _e('Remove'); ?></a>
+					</div>
+				</div>
+			</li>
+			<?php endwhile; ?>
+		</ul>
+		<div class="clear"></div>
+	</div>
+	<?php else: ?>
+	<p><?php _e('No media attachments found.'); ?></p>
+	<?php endif; ?>

--- a/src/ij-post-attachments.php
+++ b/src/ij-post-attachments.php
@@ -113,9 +113,14 @@ class IJ_Post_Attachments
 		if ($hook_suffix == 'post.php')
 		{
 			wp_enqueue_script('syoHint', $this->pluginURL . 'scripts/jquery.syoHint.js', array('jquery'), '1.0.10');
-			wp_enqueue_script('ij-post-attachments', $this->pluginURL . 'scripts/ij-post-attachments.js', array('syoHint', 'jquery-ui-sortable'), '0.0.1');
+			wp_enqueue_script(
+				'ij-post-attachments', $this->pluginURL . 'scripts/ij-post-attachments.js',
+				array('syoHint', 'jquery-ui-sortable'), '0.0.1');
 
-			wp_localize_script('ij-post-attachments', 'IJ_Post_Attachments_Vars', array('editMedia' => __('Edit Media')));
+			wp_localize_script('ij-post-attachments', 'IJ_Post_Attachments_Vars', array(
+				'editMedia' => __('Edit Media'),
+				'postID'    => isset($_GET['post']) ? $_GET['post'] : 0
+			));
 		}
 	}
 
@@ -220,12 +225,19 @@ class IJ_Post_Attachments
 	 */
 	public function attachmentEditHeadIframe()
 	{
+		global $wp_scripts;
+		wp_default_scripts($wp_scripts);
+
 		// I don't know if all these scripts are really needed by the media edit screen.
 		// They're just there, so they'll be here too :P
 		?>
 		<link rel="stylesheet" type="text/css" href="<?php echo site_url('wp-includes/js/imgareaselect/imgareaselect.css'); ?>" />
-		<script type="text/javascript" src="<?php echo admin_url('load-scripts.php?load=jquery-color,imgareaselect,image-edit,wp-ajax-response'); ?>"></script>
+		<script type="text/javascript" src="<?php echo admin_url('load-scripts.php?load=jquery-color,imgareaselect,image-edit,wp-ajax-response,set-post-thumbnail'); ?>"></script>
 		<?php
+
+		// Add the needed vars to set the thumbnail :)
+		$wp_scripts->localize('set-post-thumbnail', 'post_id', $_GET['post_id']);
+		$wp_scripts->print_extra_script('set-post-thumbnail');
 	}
 
 	/**

--- a/src/ij-post-attachments.php
+++ b/src/ij-post-attachments.php
@@ -115,7 +115,8 @@ class IJ_Post_Attachments
 			wp_enqueue_script('syoHint', $this->pluginURL . 'scripts/jquery.syoHint.js', array('jquery'), '1.0.10');
 			wp_enqueue_script(
 				'ij-post-attachments', $this->pluginURL . 'scripts/ij-post-attachments.js',
-				array('syoHint', 'jquery-ui-sortable'), '0.0.1');
+				array('syoHint', 'jquery-ui-sortable'), '0.0.2a'
+			);
 
 			wp_localize_script('ij-post-attachments', 'IJ_Post_Attachments_Vars', array(
 				'editMedia' => __('Edit Media'),

--- a/src/ij-post-attachments.php
+++ b/src/ij-post-attachments.php
@@ -213,6 +213,10 @@ class IJ_Post_Attachments
 	{
 		add_action('admin_head-media-upload-popup', array($this, 'attachmentEditHeadIframe'));
 		wp_iframe(array($this, 'attachmentEditIframe'));
+
+		// Without the line below, the WP AJAX caller (admin-ajax.php) would print an '0'
+		// at the end of the request.
+		die;
 	}
 	//</editor-fold>
 

--- a/src/scripts/ij-post-attachments.js
+++ b/src/scripts/ij-post-attachments.js
@@ -113,7 +113,9 @@ var IJ_Post_Attachments;
 						title   : LI.data('title')
 					});
 			} else {
-				el = $('<a/>').text(LI.data('title')).attr('href', LI.data('url'));
+				el = $('<a/>')
+						.text(LI.data('title'))
+						.attr('href', LI.data('url'));
 			}
 
 			send_to_editor(el[0].outerHTML);
@@ -197,4 +199,5 @@ var IJ_Post_Attachments;
 
 		this.setup();
 	}
+
 })(jQuery);

--- a/src/scripts/ij-post-attachments.js
+++ b/src/scripts/ij-post-attachments.js
@@ -134,7 +134,7 @@ var IJ_Post_Attachments;
 			// its better to keep it at the last position
 			tb_show(
 				self.editMediaTitle,
-				self.pluginUrl + 'ij-post-attachments.php?width=630&height=440&attachment_id=' + ID + '&post_id=' + self.postID + 'TB_iframe=1'
+				ajaxurl + '?action=ij_attachment_edit&width=630&height=440&attachment_id=' + ID + '&post_id=' + self.postID + 'TB_iframe=1'
 			);
 
 			return false;

--- a/src/scripts/ij-post-attachments.js
+++ b/src/scripts/ij-post-attachments.js
@@ -9,6 +9,8 @@ var IJ_Post_Attachments;
 	 * @constructor
 	 */
 	function InJoin_PostAttachments() {
+		"use strict";
+
 		var self = this;
 
 		/**
@@ -71,8 +73,9 @@ var IJ_Post_Attachments;
 						alignment = [],
 						loader = $('<img />');
 
-					for (; i < LI.length; i++)
+					for (; i < LI.length; i++) {
 						alignment.push(LI.eq(i).data('attachmentid'));
+					}
 
 					loader
 						.attr('src', userSettings.url + 'wp-admin/images/wpspin_light.gif')

--- a/src/scripts/ij-post-attachments.js
+++ b/src/scripts/ij-post-attachments.js
@@ -30,6 +30,12 @@ var IJ_Post_Attachments;
 		this.editMediaTitle = IJ_Post_Attachments_Vars.editMedia;
 
 		/**
+		 * Current post ID
+		 * @type {Number}
+		 */
+		this.postID = IJ_Post_Attachments_Vars.postID;
+
+		/**
 		 * Defines whether we're dragging around or not
 		 * @type {Boolean}
 		 */
@@ -121,7 +127,10 @@ var IJ_Post_Attachments;
 
 			// Because ThickBox removes everything after the TB_iframe parameter,
 			// its better to keep it at the last position
-			tb_show(self.editMediaTitle, self.pluginUrl + 'ij-post-attachments.php?width=630&height=440&attachment_id=' + ID + '&TB_iframe=1');
+			tb_show(
+				self.editMediaTitle,
+				self.pluginUrl + 'ij-post-attachments.php?width=630&height=440&attachment_id=' + ID + '&post_id=' + self.postID + 'TB_iframe=1'
+			);
 
 			return false;
 		};


### PR DESCRIPTION
New version 0.1.0a.
Features of this version:
- **"Use as thumbnail"** link in the attachment edition screen
- HTML moved to separate files
- PHP code more compliant with [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- JS code more compliant with [JSHint](http://www.jshint.com)
